### PR TITLE
redesign exam schedule interface and exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,19 @@ easeCHAOS is a modern, user-friendly timetable viewer designed specifically for 
 - **Simplified View**: No more squinting at Excel sheets or searching through merged cells
 - **Class-Specific**: View only your class's schedule, filtered and clean
 - **Modern Interface**: Intuitive weekly and daily views
+- **Exam Schedule Support**: Browse the exam period as a month view, agenda, or short-term windows
 - **Mobile Friendly**: Access your schedule on any device
-- **Download Options**: Download your schedule in pdf and image.
+- **Download Options**: Download schedules as PDF, image, or calendar (`.ics`) files.
 
 ## Current Progress
 
 The application currently features:
 - ✅ Weekly view with all classes
 - ✅ Daily detailed view
-- ✅ Class filtering system
+- ✅ Exam schedule views for `All Exams`, `Today`, `This Week`, and `Next Week`
+- ✅ Exam month calendar and agenda view
 - ✅ Responsive design with Light and Dark Theme
-- ✅ Calendar download (PDF & Image)
+- ✅ Lecture and exam export downloads (PDF, Image, and `.ics` for exam agenda)
 - ✅ Accessible as Progressive Web App (PWA). You can basically save for offline use once your schedule is loaded up
 
 ## Getting Started
@@ -52,23 +54,35 @@ For detailed documentation, see the [docs/](./docs) folder:
 
 - **[Data Extraction Documentation](./docs/data-extraction.md)** - Excel format requirements
 
-
-
 ### Installation (Local without Docker)
 1. Clone the repository
 2. Ensure you have `make` installed (available on most linux flavored systems)
 3. Copy and rename `.env.sample` to `.env`
-4. Run `make local` to start the application on local. However, before that, note that you would need a `redis` instance. You could create one on [upstash.com](https://upstash.com/) and just place the details in the `.env` file.
-
+4. Ensure you have a Redis instance available and set the connection values in `.env`
+5. Run `make local`
 
 ### Installation (Docker)
 
 1. Clone the repository
 2. Copy and rename `.env.sample` to `.env`
-3. Run `make up` to start the application on docker.
-4. Open `http://localhost:5173` for the frontend and `http://localhost:8000/api/v1/healthcheck` to confirm the API is running.
+3. Run `make up` or `docker compose -f docker-compose.dev.yml up`
+4. Open the app at `http://localhost:5173`
+5. API healthcheck is available at `http://localhost:8000/api/v1/healthcheck`
+
+To stop the Docker stack:
+
+```bash
+make down
+```
+
+## Notes About Source Data
 
 NB: This project is still under development. You might encounter bugs with the processed data. However, issues stem from the drafts, and has nothing to do with the extractor in most cases. Refer to the IT department and respective class reps to resolve clashes and unfamiliar conventions.
+
+- Lecture and exam accuracy still depends on the source spreadsheets.
+- If a class appears in the lecture timetable but not in the exam timetable, check the exam workbook first.
+- Exam rows may be repeated once per class group in the source file. The frontend groups those rows into a single paper for display.
+- `All Exams` → `Agenda` supports export as `PDF`, `PNG`, and `.ics` for importing exam papers into calendar apps.
 
 ### Current Progress
 

--- a/api/extract/extract_exam_table.py
+++ b/api/extract/extract_exam_table.py
@@ -1,50 +1,58 @@
 import pandas as pd
 
+PERIOD_MAPPING = {
+    "M": ("7:00 AM", "10:00 AM"),
+    "A": ("11:00 AM", "2:00 PM"),
+    "E": ("3:00 PM", "6:00 PM"),
+}
 
-def _normalize_exam_columns(df: pd.DataFrame) -> pd.DataFrame:
-    """Normalize exam workbook columns across draft variants."""
-    normalized = df.copy()
-    normalized.columns = [str(col).strip() for col in normalized.columns]
+COLUMN_ALIASES = {
+    "COURSE NO": ["COURSE NO", "CRS CODE"],
+    "COURSE NAME": ["COURSE NAME", "COURSE TITLE"],
+    "CLASS": ["CLASS"],
+    "LECTURER": ["LECTURER", "EXAMINER"],
+    "LECTURE HALL": ["LECTURE HALL", "ROOM"],
+    "INVIGILATOR (UPDATED)": ["INVIGILATOR (UPDATED)", "INVIGILATOR"],
+    "PERIOD": ["PERIOD", "SESSION"],
+    "NO": ["NO", "No."],
+}
 
-    session_col = "PERIOD" if "PERIOD" in normalized.columns else "SESSION"
-    course_col = (
-        "COURSE NAME" if "COURSE NAME" in normalized.columns else "COURSE TITLE"
-    )
-    hall_col = "LECTURE HALL" if "LECTURE HALL" in normalized.columns else "ROOM"
-    invigilator_col = (
-        "INVIGILATOR (UPDATED)"
-        if "INVIGILATOR (UPDATED)" in normalized.columns
-        else "INVIGILATOR"
-    )
-    number_col = "NO" if "NO" in normalized.columns else "No."
 
-    rename_map = {
-        session_col: "PERIOD",
-        course_col: "COURSE NAME",
-        hall_col: "LECTURE HALL",
-        invigilator_col: "INVIGILATOR (UPDATED)",
-        number_col: "NO",
-    }
+def _find_header_row(df: pd.DataFrame) -> int:
+    for index in range(len(df)):
+        row = [str(value).strip() for value in df.iloc[index].tolist()]
+        if "DATE" in row and ("CLASS" in row or "SESSION" in row or "PERIOD" in row):
+            return index
 
-    return normalized.rename(columns=rename_map)
+    raise ValueError("Could not find exam timetable header row")
+
+
+def _resolve_column_name(columns: pd.Index, candidates: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+    return None
+
+
+def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    renamed_columns: dict[str, str] = {}
+
+    for canonical_name, aliases in COLUMN_ALIASES.items():
+        source_name = _resolve_column_name(df.columns, aliases)
+        if source_name:
+            renamed_columns[source_name] = canonical_name
+
+    return df.rename(columns=renamed_columns)
 
 
 def _convert_exam_dates(date_series: pd.Series) -> pd.Series:
-    """Normalize exam date values to a datetime-like Series.
-
-    Accepts a Series containing either Excel serial date numbers or already
-    parsed datetime-like values and returns a Series of pandas datetime
-    objects. String formatting for display is performed separately (e.g. in
-    ``format_date_with_suffix``).
-    """
+    """Normalize Excel serial dates and datetime-like values."""
     numeric_dates = pd.to_numeric(date_series, errors="coerce")
 
     if numeric_dates.notna().all():
-        converted = pd.to_datetime(numeric_dates, unit="D", origin="1899-12-30")
-    else:
-        converted = pd.to_datetime(date_series, errors="coerce")
+        return pd.to_datetime(numeric_dates, unit="D", origin="1899-12-30")
 
-    return converted
+    return pd.to_datetime(date_series, errors="coerce")
 
 
 def get_exam_timetable(filename, class_pattern) -> pd.DataFrame:
@@ -58,61 +66,41 @@ def get_exam_timetable(filename, class_pattern) -> pd.DataFrame:
     Returns:
     pd.DataFrame: Processed and filtered timetable DataFrame
     """
+    raw_df = pd.read_excel(filename, sheet_name=0, header=None)
 
-    # read the Excel file
-    df = pd.read_excel(filename, sheet_name=0, header=None)
-
-    # Remove empty columns and locate the header row dynamically.
+    header_row = _find_header_row(raw_df)
+    df = raw_df.iloc[header_row:].reset_index(drop=True)
+    df.columns = [str(value).strip() for value in df.iloc[0].tolist()]
+    df = df[1:].reset_index(drop=True)
+    df = _normalize_columns(df)
     df = df.dropna(axis=1, how="all")
-    header_row_index = None
-    for idx, row in df.iterrows():
-        values = {str(value).strip() for value in row.dropna().tolist()}
-        if "DATE" in values and ("PERIOD" in values or "SESSION" in values):
-            header_row_index = idx
-            break
 
-    if header_row_index is None:
-        raise ValueError("Could not locate exam timetable header row")
+    period_col = _resolve_column_name(df.columns, ["PERIOD"])
+    if not period_col:
+        raise ValueError("Exam timetable is missing PERIOD/SESSION column")
 
-    df_cleaned = df.iloc[header_row_index:].reset_index(drop=True)
-    df_cleaned.columns = df_cleaned.iloc[0]
-    df_cleaned = df_cleaned[1:].reset_index(drop=True)
-    df_cleaned = _normalize_exam_columns(df_cleaned)
+    df[period_col] = df[period_col].astype(str).str.strip()
+    df = df[df[period_col].isin(PERIOD_MAPPING.keys())]
 
-    # map PERIOD to START and END times
-    period_mapping = {
-        "M": ("7:00 AM", "10:00 AM"),
-        "A": ("11:00 AM", "2:00 PM"),
-        "E": ("3:00 PM", "6:00 PM"),
-    }
+    df["START"], df["END"] = zip(*df[period_col].map(PERIOD_MAPPING))
+    df = df.drop(columns=[period_col])
 
-    # conver the 'PERIOD' column to string type to handle NaN vals
-    df_cleaned["PERIOD"] = df_cleaned["PERIOD"].astype(str)
-    df_cleaned = df_cleaned[df_cleaned["PERIOD"].isin(period_mapping.keys())]
-
-    # apply the mapping for valid periods
-    df_cleaned["START"], df_cleaned["END"] = zip(
-        *df_cleaned["PERIOD"].map(period_mapping)
-    )
-
-    # remove the PERIOD column
-    df_cleaned = df_cleaned.drop(columns=["PERIOD"])
-
-    # format date helper function
     def format_date_with_suffix(date):
         day = date.day
         suffix = (
-            "th" if 11 <= day <= 13 else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
+            "th"
+            if 11 <= day <= 13
+            else {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
         )
         return date.strftime(f"%A, {day}{suffix} %B %Y")
 
-    # process dates
-    df_cleaned["DATE"] = _convert_exam_dates(df_cleaned["DATE"])
-    df_cleaned = df_cleaned[df_cleaned["DATE"].notna()]
-    df_cleaned["DATE"] = df_cleaned["DATE"].apply(format_date_with_suffix)
+    df["DATE"] = _convert_exam_dates(df["DATE"])
+    df = df[df["DATE"].notna()].copy()
+    df["DATE"] = df["DATE"].apply(format_date_with_suffix)
 
-    # filter by class pattern
-    filtered_df = df_cleaned[df_cleaned["CLASS"].str.startswith(class_pattern)]
-    filtered_df = filtered_df.drop(columns=["NO"], errors="ignore")
+    filtered_df = df[df["CLASS"].astype(str).str.startswith(class_pattern)].copy()
+
+    if "NO" in filtered_df.columns:
+        filtered_df = filtered_df.drop(columns=["NO"])
 
     return filtered_df

--- a/api/extract/extract_exam_table.py
+++ b/api/extract/extract_exam_table.py
@@ -82,7 +82,12 @@ def get_exam_timetable(filename, class_pattern) -> pd.DataFrame:
     df[period_col] = df[period_col].astype(str).str.strip()
     df = df[df[period_col].isin(PERIOD_MAPPING.keys())]
 
-    df["START"], df["END"] = zip(*df[period_col].map(PERIOD_MAPPING))
+    if df.empty:
+        # No valid PERIOD/SESSION rows; propagate an empty result without raising.
+        df["START"] = pd.Series(dtype=object)
+        df["END"] = pd.Series(dtype=object)
+    else:
+        df["START"], df["END"] = zip(*df[period_col].map(PERIOD_MAPPING))
     df = df.drop(columns=[period_col])
 
     def format_date_with_suffix(date):

--- a/docs/data-extraction.md
+++ b/docs/data-extraction.md
@@ -58,23 +58,38 @@ The extraction system supports various class naming patterns:
 ## Exam Timetable Format
 
 ### Excel Structure
-```
-┌─────────────────────────────────────────────────────────┐
-│ Single sheet with exam schedule                         │
-├─────────┬─────────┬─────────┬─────────┬─────────────────┤
-│ NO      │ DATE    │ CLASS   │ COURSE  │ LECTURE HALL    │
-├─────────┼─────────┼─────────┼─────────┼─────────────────┤
-│ 1       │ 15/01/24│ CE 4    │ MATH 301│ LT 1            │
-│ 2       │ 16/01/24│ MECH 3  │ PHYS 201│ Lab 2           │
-└─────────┴─────────┴─────────┴─────────┴─────────────────┘
+``` 
+┌────────────────────────────────────────────────────────────────────────────┐
+│ Single sheet with exam schedule                                            │
+├────────────┬──────────┬──────────────────────┬────────┬─────┬──────────────┤
+│ DATE       │ CRS CODE │ COURSE TITLE         │ CLASS  │ No. │ ROOM         │
+├────────────┼──────────┼──────────────────────┼────────┼─────┼──────────────┤
+│ 07/04/2026 │ EC 251   │ GENERAL PYSCHOLOGY   │ EC 2A  │ 50  │ CCG2         │
+│ 07/04/2026 │ LT 251   │ GENERAL PYSCHOLOGY   │ LT 2B  │ 50  │ LH 6         │
+└────────────┴──────────┴──────────────────────┴────────┴─────┴──────────────┘
 ```
 
 ### Key Requirements
 
-1. **Header Row**: Column names in row 4 (after skipping first 3 rows)
-2. **Period Column**: Uses codes M (Morning), A (Afternoon), E (Evening)
-3. **Date Format**: Excel date format (DD/MM/YYYY or similar)
-4. **Class Column**: Course codes for filtering
+1. **Single Sheet**: Exam timetable is stored on one sheet
+2. **Header Detection**: The extractor searches for a row containing `DATE`, `CLASS`, and either `PERIOD` or `SESSION`
+3. **Session Codes**: Uses `M`, `A`, `E` for morning, afternoon, and evening
+4. **Date Format**: Excel date values are converted to readable strings with suffixes
+5. **Class Prefix**: Class rows are filtered with `str.startswith(class_pattern)`
+
+### Supported Exam Column Names
+
+The extractor supports both older and newer workbook variants by normalizing columns internally.
+
+| Normalized Output | Accepted Source Columns |
+|-------------------|-------------------------|
+| `COURSE NO` | `COURSE NO`, `CRS CODE` |
+| `COURSE NAME` | `COURSE NAME`, `COURSE TITLE` |
+| `LECTURER` | `LECTURER`, `EXAMINER` |
+| `LECTURE HALL` | `LECTURE HALL`, `ROOM` |
+| `INVIGILATOR (UPDATED)` | `INVIGILATOR (UPDATED)`, `INVIGILATOR` |
+| `PERIOD` | `PERIOD`, `SESSION` |
+| `NO` | `NO`, `No.` |
 
 ### Period Mapping
 
@@ -88,10 +103,11 @@ period_mapping = {
 
 ### Processing Logic
 
-1. **Header Detection**: Skips first 3 rows, uses 4th row as headers
-2. **Period Conversion**: Maps period codes to time ranges
-3. **Date Formatting**: Converts Excel dates to readable format with suffixes
-4. **Class Filtering**: Filters by class pattern using `str.startswith()`
+1. **Header Detection**: Finds the real header row dynamically
+2. **Column Normalization**: Maps old and new column names into one schema
+3. **Period Conversion**: Maps period or session codes to time ranges
+4. **Date Formatting**: Converts Excel dates to readable format with suffixes
+5. **Class Filtering**: Filters by class pattern using `str.startswith()`
 
 ## Data Extraction Functions
 
@@ -131,10 +147,12 @@ period_mapping = {
 #### `get_exam_timetable(filename, class_pattern)`
 - **Purpose**: Extract exam schedule from Excel file
 - **Process**:
-  1. Reads Excel with specific header positioning
-  2. Maps period codes to time ranges
-  3. Formats dates with readable suffixes
-  4. Filters by class pattern
+  1. Reads the raw sheet without fixed headers
+  2. Detects the actual header row
+  3. Normalizes workbook column names
+  4. Maps period or session codes to time ranges
+  5. Formats dates with readable suffixes
+  6. Filters by class pattern
 - **Returns**: Filtered exam timetable DataFrame
 
 ## Time Format Handling
@@ -191,10 +209,10 @@ period_mapping = {
 
 ### Sample Exam Timetable Entry
 ```excel
-| NO | DATE       | CLASS | COURSE NAME | LECTURE HALL | PERIOD |
-|----|------------|-------|-------------|--------------|--------|
-| 1  | 15/01/2024 | CE 4  | MATH 301    | LT 1         | M      |
-| 2  | 16/01/2024 | MECH 3| PHYS 201    | Lab 2        | A      |
+| DATE       | CRS CODE | COURSE TITLE             | CLASS | ROOM | SESSION |
+|------------|----------|--------------------------|-------|------|---------|
+| 10/04/2026 | CE 461   | Industrial Electronics   | CE 4A | GF 1 | M       |
+| 16/04/2026 | CE 469   | Fundamentals of Robotics | CE 4B | SF 2 | E       |
 ```
 
 ## Integration with API
@@ -211,12 +229,14 @@ period_mapping = {
 - Exam: Date-based structure with exam details
 - Both include location, time, and course information
 
+For exams, the backend returns one row per class group. The frontend groups repeated rows for the same paper so one paper can appear once with multiple classes beneath it.
+
 ## File Management
 
 ### Storage Location
-- Lecture timetables: `drafts/` directory
-- Exam timetables: Same directory with different naming
-- File naming: `Draft_1.xlsx`, `Draft_2.xlsx`, etc.
+- Lecture timetables: `api/drafts/`
+- Exam timetables: `api/drafts/`
+- Example file naming: `Draft_1.xlsx`, `Draft_2.xlsx`, `Draft_1_ex.xlsx`
 
 ### Version Control
 - File hash detection for changes
@@ -230,6 +250,8 @@ period_mapping = {
 2. **Class Pattern Matching**: Verify regex patterns for department codes
 3. **Merged Cell Problems**: Ensure proper cell merging in Excel
 4. **Sheet Name Issues**: Use exact day names for lecture timetables
+5. **Exam Header Issues**: Ensure the workbook still includes `DATE`, `CLASS`, and `SESSION` or `PERIOD`
+6. **Missing Exam Rows**: If a class exists in lectures but not exams, verify the exam workbook actually includes that class prefix
 
 ### Debugging Tips
 - Check raw Excel data before processing

--- a/docs/data-extraction.md
+++ b/docs/data-extraction.md
@@ -64,8 +64,8 @@ The extraction system supports various class naming patterns:
 ├────────────┬──────────┬──────────────────────┬────────┬─────┬──────────────┤
 │ DATE       │ CRS CODE │ COURSE TITLE         │ CLASS  │ No. │ ROOM         │
 ├────────────┼──────────┼──────────────────────┼────────┼─────┼──────────────┤
-│ 07/04/2026 │ EC 251   │ GENERAL PYSCHOLOGY   │ EC 2A  │ 50  │ CCG2         │
-│ 07/04/2026 │ LT 251   │ GENERAL PYSCHOLOGY   │ LT 2B  │ 50  │ LH 6         │
+│ 07/04/2026 │ EC 251   │ GENERAL PSYCHOLOGY   │ EC 2A  │ 50  │ CCG2         │
+│ 07/04/2026 │ LT 251   │ GENERAL PSYCHOLOGY   │ LT 2B  │ 50  │ LH 6         │
 └────────────┴──────────┴──────────────────────┴────────┴─────┴──────────────┘
 ```
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,8 @@ function AppContent() {
   }, [location]);
 
   const lastPath = shouldRedirect ? localStorage.getItem("lastPath") : null;
-  const isValidTimetablePath = lastPath?.startsWith("/timetable/");
+  const isValidSavedPath =
+    lastPath?.startsWith("/timetable/") || lastPath?.startsWith("/exam/");
 
   useEffect(() => {
     setShouldRedirect(false);
@@ -33,7 +34,7 @@ function AppContent() {
       <Route
         path="/"
         element={
-          isValidTimetablePath ? (
+          isValidSavedPath ? (
             <Navigate to={lastPath!} replace />
           ) : (
             <LandingPage />

--- a/frontend/src/components/ExamView.tsx
+++ b/frontend/src/components/ExamView.tsx
@@ -1,363 +1,1173 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
 import {
+  addDays,
+  addMonths,
+  addWeeks,
+  endOfWeek,
+  endOfMonth,
   format,
-  isToday,
-  isThisWeek,
   isAfter,
   isBefore,
-  addWeeks,
-  subWeeks,
+  isSameDay,
+  isSameMonth,
+  isToday,
+  startOfDay,
+  startOfMonth,
+  startOfToday,
+  startOfWeek,
+  subMonths,
 } from "date-fns";
 import {
-  Calendar,
-  Clock,
-  MapPin,
-  Users,
   ChevronLeft,
   ChevronRight,
+  Clock3,
+  LayoutGrid,
+  type LucideIcon,
+  MapPin,
+  NotebookTabs,
+  Rows3,
+  UserRound,
+  Users,
 } from "lucide-react";
-import clsx from "clsx";
 import { ExamData, DayData, TimetableData } from "../types";
+import {
+  downloadEventsAsICS,
+  downloadElementAsImage,
+  downloadElementAsPDF,
+} from "../utils/downloadUtils";
+import easeChaosLogo from "../../assets/easechaos.png";
 
 interface ExamViewProps {
   timetableData: TimetableData;
-  selectedClass?: string;
   className?: string;
+  exportLabel?: string;
 }
 
-const parseDate = (dateStr: string) => {
-  const [dayName, dayNum, month, year] = dateStr.split(/,\s+|th\s+|\s+/);
-  const monthMap: Record<string, number> = {
-    January: 0,
-    February: 1,
-    March: 2,
-    April: 3,
-    May: 4,
-    June: 5,
-    July: 6,
-    August: 7,
-    September: 8,
-    October: 9,
-    November: 10,
-    December: 11,
-  };
+type ExamWindow = "today" | "this-week" | "next-week" | "all";
+type AllExamsView = "month" | "agenda";
 
-  return new Date(parseInt(year), monthMap[month], parseInt(dayNum));
-};
+interface SubjectGroup {
+  name: string;
+  start: string;
+  end: string;
+  exams: ExamData[];
+}
+
+interface DayGroup {
+  day: string;
+  date: Date;
+  subjects: SubjectGroup[];
+  totalExams: number;
+}
+
+const examWindows: {
+  id: ExamWindow;
+  shortLabel: string;
+}[] = [
+  {
+    id: "all",
+    shortLabel: "All Exams",
+  },
+  {
+    id: "today",
+    shortLabel: "Today",
+  },
+  {
+    id: "this-week",
+    shortLabel: "This Week",
+  },
+  {
+    id: "next-week",
+    shortLabel: "Next Week",
+  },
+];
+
+const weekdayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const panelClasses =
+  "border border-[#E4E4E7] bg-white dark:border-[#303030] dark:bg-[#262626]";
+const subtleSurfaceClasses = "bg-[#FAFAFA] dark:bg-[#303030]";
+const primaryTextClasses = "text-[#111827] dark:text-[#F0F6FC]";
+const mutedTextClasses = "text-[#71717A] dark:text-[#B2B2B2]";
+const accentSoftClasses =
+  "bg-blue-50 text-blue-700 dark:bg-[#1E3A5F] dark:text-[#BFDBFE]";
+const accentStrongClasses =
+  "bg-[#2457A7] text-white dark:bg-[#4593F8] dark:text-[#02040A]";
+
+function parseExamDate(dateLabel: string): Date {
+  const cleanedLabel = dateLabel.replace(
+    /(\d+)(st|nd|rd|th)/g,
+    (_, dayNumber) => dayNumber,
+  );
+
+  return new Date(cleanedLabel);
+}
+
+function countGroupedPapers(days: DayGroup[]): number {
+  return days.reduce((total, day) => total + day.subjects.length, 0);
+}
+
+function formatPaperCount(count: number): string {
+  return `${count} paper${count === 1 ? "" : "s"}`;
+}
+
+function formatClassCount(count: number): string {
+  return `${count} class${count === 1 ? "" : "es"}`;
+}
+
+function formatClassList(exams: ExamData[]): string {
+  return exams.map((exam) => exam.class).join(", ");
+}
+
+function getUniqueLocations(exams: ExamData[]): string[] {
+  return Array.from(
+    new Set(
+      exams
+        .map((exam) => exam.location)
+        .filter((location): location is string => Boolean(location)),
+    ),
+  );
+}
+
+function formatExamWindowLabel(window: ExamWindow): string {
+  switch (window) {
+    case "today":
+      return "today";
+    case "this-week":
+      return "the rest of this week";
+    case "next-week":
+      return "next week";
+    case "all":
+      return "the full exam period";
+  }
+}
+
+function getWindowDescription(activeWindow: ExamWindow): string {
+  switch (activeWindow) {
+    case "today":
+      return "Only papers scheduled for today.";
+    case "this-week":
+      return "Papers still coming later this week.";
+    case "next-week":
+      return "The next calendar week of exams.";
+    case "all":
+      return "The full exam period on one calendar.";
+  }
+}
+
+function getDateKey(date: Date) {
+  return format(startOfDay(date), "yyyy-MM-dd");
+}
+
+function parseTimeToDate(date: Date, time: string) {
+  const [hours, minutes] = time.split(":").map(Number);
+  const nextDate = new Date(date);
+  nextDate.setHours(hours, minutes, 0, 0);
+  return nextDate;
+}
+
+function createSubjectGroup(exam: ExamData): SubjectGroup {
+  return {
+    name: exam.value,
+    start: exam.start,
+    end: exam.end,
+    exams: [exam],
+  };
+}
+
+function organizeExamsByDayAndSubject(data: DayData[]): DayGroup[] {
+  const groupedDays = new Map<string, DayGroup>();
+
+  data.forEach((dayEntry) => {
+    const date = startOfDay(parseExamDate(dayEntry.day));
+    const existingDay = groupedDays.get(dayEntry.day);
+
+    if (!existingDay) {
+      groupedDays.set(dayEntry.day, {
+        day: dayEntry.day,
+        date,
+        subjects: [],
+        totalExams: 0,
+      });
+    }
+
+    const currentDay = groupedDays.get(dayEntry.day)!;
+    const subjectsByName = new Map(
+      currentDay.subjects.map((subject) => [subject.name, subject]),
+    );
+
+    dayEntry.data.forEach((exam) => {
+      const existingSubject = subjectsByName.get(exam.value);
+
+      if (!existingSubject) {
+        const subjectGroup = createSubjectGroup(exam);
+        currentDay.subjects.push(subjectGroup);
+        subjectsByName.set(exam.value, subjectGroup);
+      } else {
+        existingSubject.exams.push(exam);
+      }
+
+      currentDay.totalExams += 1;
+    });
+  });
+
+  return Array.from(groupedDays.values())
+    .map((day) => ({
+      ...day,
+      subjects: day.subjects.sort((left, right) =>
+        left.start.localeCompare(right.start),
+      ),
+    }))
+    .filter((day) => day.totalExams > 0)
+    .sort((left, right) => left.date.getTime() - right.date.getTime());
+}
+
+function buildMonthDays(activeMonth: Date): Date[] {
+  const monthStart = startOfMonth(activeMonth);
+  const calendarStart = startOfWeek(monthStart, { weekStartsOn: 0 });
+  const calendarEnd = endOfWeek(endOfMonth(activeMonth), {
+    weekStartsOn: 0,
+  });
+  const monthDays: Date[] = [];
+
+  for (
+    let date = calendarStart;
+    !isAfter(date, calendarEnd);
+    date = addDays(date, 1)
+  ) {
+    monthDays.push(date);
+  }
+
+  return monthDays;
+}
+
+function buildExamCalendarEvents(days: DayGroup[]) {
+  return days.flatMap((day) =>
+    day.subjects.map((subject) => {
+      const locations = getUniqueLocations(subject.exams);
+      const invigilators = Array.from(
+        new Set(
+          subject.exams
+            .map((exam) => exam.invigilator)
+            .filter((invigilator): invigilator is string =>
+              Boolean(invigilator),
+            ),
+        ),
+      );
+
+      return {
+        start: parseTimeToDate(day.date, subject.start),
+        end: parseTimeToDate(day.date, subject.end),
+        summary: subject.name,
+        location: locations.join(", "),
+        description: [
+          `Classes: ${formatClassList(subject.exams)}`,
+          locations.length ? `Venue: ${locations.join(", ")}` : null,
+          invigilators.length
+            ? `Invigilator${invigilators.length === 1 ? "" : "s"}: ${invigilators.join(", ")}`
+            : null,
+          "Exported from EaseCHAOS",
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      };
+    }),
+  );
+}
+
+interface WindowTabButtonProps {
+  count: number;
+  isActive: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function WindowTabButton({
+  count,
+  isActive,
+  label,
+  onClick,
+}: WindowTabButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        "inline-flex w-full items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors sm:w-auto sm:justify-start sm:gap-3",
+        isActive
+          ? "border-[#D4D4D8] bg-white text-[#111827] shadow-sm dark:border-[#303030] dark:bg-[#262626] dark:text-[#F0F6FC]"
+          : "border-[#E4E4E7] bg-[#FAFAFA] text-[#71717A] hover:bg-white dark:border-[#303030] dark:bg-[#303030] dark:text-[#B2B2B2] dark:hover:bg-[#3A3A3A]",
+      )}
+    >
+      <span className="truncate">{label}</span>
+      <span
+        className={clsx(
+          "inline-flex min-w-7 items-center justify-center rounded-sm px-2 py-0.5 text-xs font-semibold",
+          isActive
+            ? "bg-[#F4F4F5] text-[#111827] dark:bg-[#303030] dark:text-[#F0F6FC]"
+            : "bg-white text-[#52525B] dark:bg-[#262626] dark:text-[#B2B2B2]",
+        )}
+      >
+        {count}
+      </span>
+    </button>
+  );
+}
+
+interface ViewModeButtonProps {
+  icon: LucideIcon;
+  isActive: boolean;
+  label: string;
+  onClick: () => void;
+}
+
+function ViewModeButton({
+  icon: Icon,
+  isActive,
+  label,
+  onClick,
+}: ViewModeButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        "inline-flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
+        isActive
+          ? "bg-white text-[#111827] shadow-sm dark:bg-[#262626] dark:text-[#F0F6FC]"
+          : "text-[#71717A] dark:text-[#B2B2B2]",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {label}
+    </button>
+  );
+}
+
+interface ExamClassRowProps {
+  exam: ExamData;
+}
+
+function ExamClassRow({ exam }: ExamClassRowProps) {
+  return (
+    <div
+      className={clsx(
+        "flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:justify-between",
+        panelClasses,
+        subtleSurfaceClasses,
+      )}
+    >
+      <div
+        className={clsx(
+          "inline-flex items-center gap-2 text-sm font-medium",
+          primaryTextClasses,
+        )}
+      >
+        <Users className={clsx("h-4 w-4", mutedTextClasses)} />
+        {exam.class}
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <div
+          className={clsx(
+            "inline-flex items-center gap-2 text-sm",
+            mutedTextClasses,
+          )}
+        >
+          <MapPin className="h-4 w-4" />
+          {exam.location}
+        </div>
+
+        {exam.invigilator ? (
+          <div
+            className={clsx(
+              "inline-flex items-center gap-2 text-sm",
+              mutedTextClasses,
+            )}
+          >
+            <UserRound className="h-4 w-4" />
+            {exam.invigilator}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface SubjectMetaProps {
+  classCount: number;
+  end: string;
+  start: string;
+}
+
+function SubjectMeta({ classCount, end, start }: SubjectMetaProps) {
+  return (
+    <div
+      className={clsx(
+        "flex flex-wrap gap-4 text-sm font-medium",
+        mutedTextClasses,
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        <Clock3 className="h-4 w-4" />
+        <span>
+          {start} - {end}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1.5">
+        <Users className="h-4 w-4" />
+        <span>{formatClassCount(classCount)}</span>
+      </div>
+    </div>
+  );
+}
+
+interface AgendaPaperCardProps {
+  subject: SubjectGroup;
+}
+
+function AgendaPaperCard({ subject }: AgendaPaperCardProps) {
+  const locations = getUniqueLocations(subject.exams);
+  const primaryLocation = locations[0];
+  const secondaryLocationCount = Math.max(locations.length - 3, 0);
+
+  return (
+    <article className={clsx("overflow-hidden rounded-xl", panelClasses)}>
+      <div className="flex flex-col gap-5 px-5 py-5 lg:grid lg:grid-cols-[minmax(0,1fr)_11rem] lg:items-center lg:px-6">
+        <div className="min-w-0">
+          <h4
+            className={clsx(
+              "text-xl font-semibold leading-tight",
+              primaryTextClasses,
+            )}
+          >
+            {subject.name}
+          </h4>
+
+          <div
+            className={clsx(
+              "mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm",
+              mutedTextClasses,
+            )}
+          >
+            <div className="inline-flex items-center gap-2">
+              <Clock3 className="h-4 w-4" />
+              <span>
+                {subject.start} - {subject.end}
+              </span>
+            </div>
+            <div className="inline-flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              <span>
+                {formatClassCount(subject.exams.length)} (
+                {formatClassList(subject.exams)})
+              </span>
+            </div>
+            {primaryLocation ? (
+              <div className="inline-flex items-center gap-2 lg:hidden">
+                <MapPin className="h-4 w-4" />
+                <span>{locations.join(", ")}</span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="border-t border-[#E4E4E7] pt-4 dark:border-[#303030] lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
+          <div className="flex mb-2 gap-1.5 justify-center">
+            {locations.slice(0, 3).map((location) => (
+              <span
+                key={location}
+                className={clsx(
+                  "flex h-12 w-12 items-center justify-center rounded-[0.75rem] text-[12px] font-semibold",
+                  accentSoftClasses,
+                )}
+              >
+                {location}
+              </span>
+            ))}
+            {secondaryLocationCount > 0 ? (
+              <span
+                className={clsx(
+                  "flex h-8 min-w-8 items-center justify-center rounded-full px-2 text-[11px] font-semibold",
+                  subtleSurfaceClasses,
+                  mutedTextClasses,
+                )}
+              >
+                +{secondaryLocationCount}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="mt-3 text-center sm:text-center lg:text-right">
+            <p
+              className={clsx(
+                "text-xs font-semibold uppercase tracking-[0.12em]",
+                mutedTextClasses,
+              )}
+            >
+              Venue
+            </p>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
 
 export default function ExamView({
   timetableData,
-  selectedClass = "all",
   className,
+  exportLabel = "EaseCHAOS Exam Schedule",
 }: ExamViewProps) {
-  const [currentDate, setCurrentDate] = useState<Date>(new Date());
-  const [activeTab, setActiveTab] = useState<string>("today");
+  const today = startOfToday();
+  const selectedDayDetailsRef = useRef<HTMLElement | null>(null);
+  const shouldScrollToDetailsRef = useRef(false);
+  const downloadDropdownRef = useRef<HTMLDivElement | null>(null);
+  const [activeWindow, setActiveWindow] = useState<ExamWindow>("all");
+  const [allExamsView, setAllExamsView] = useState<AllExamsView>("month");
+  const [showDownloadDropdown, setShowDownloadDropdown] = useState(false);
+  const allExamDays = organizeExamsByDayAndSubject(timetableData.data);
 
-  const organizeExamsByDayAndSubject = (
-    data: DayData[],
-    selectedClass: string,
-  ) => {
-    const result: {
-      day: string;
-      subjects: { name: string; exams: ExamData[] }[];
-    }[] = [];
+  const startCurrentWeek = startOfWeek(today, { weekStartsOn: 1 });
+  const endCurrentWeek = endOfWeek(today, { weekStartsOn: 1 });
+  const startNextWeek = addWeeks(startCurrentWeek, 1);
+  const endNextWeek = endOfWeek(startNextWeek, { weekStartsOn: 1 });
 
-    const dayGroups: Record<string, DayData[]> = {};
-    data.forEach((dayItem) => {
-      if (!dayGroups[dayItem.day]) {
-        dayGroups[dayItem.day] = [];
-      }
-      dayGroups[dayItem.day].push(dayItem);
-    });
+  const todayExams = allExamDays.filter((day) => isSameDay(day.date, today));
+  const thisWeekExams = allExamDays.filter(
+    (day) => isAfter(day.date, today) && !isAfter(day.date, endCurrentWeek),
+  );
+  const nextWeekExams = allExamDays.filter(
+    (day) =>
+      (isSameDay(day.date, startNextWeek) ||
+        isAfter(day.date, startNextWeek)) &&
+      (isSameDay(day.date, endNextWeek) || isBefore(day.date, endNextWeek)),
+  );
 
-    Object.entries(dayGroups).forEach(([day, dayItems]) => {
-      const subjectMap: Record<string, ExamData[]> = {};
-
-      dayItems.forEach((dayItem) => {
-        dayItem.data.forEach((exam) => {
-          if (selectedClass !== "all" && exam.class !== selectedClass) {
-            return;
-          }
-
-          if (!subjectMap[exam.value]) {
-            subjectMap[exam.value] = [];
-          }
-
-          subjectMap[exam.value].push(exam);
-        });
-      });
-
-      const subjects = Object.entries(subjectMap).map(([name, exams]) => ({
-        name,
-        exams,
-      }));
-      if (subjects.length > 0) {
-        result.push({ day, subjects });
-      }
-    });
-
-    return result;
+  const examGroupsByWindow: Record<ExamWindow, DayGroup[]> = {
+    today: todayExams,
+    "this-week": thisWeekExams,
+    "next-week": nextWeekExams,
+    all: allExamDays,
   };
 
-  const getTodayExams = () => {
-    const allExams = organizeExamsByDayAndSubject(
-      timetableData.data,
-      selectedClass,
-    );
-    return allExams.filter((dayExam) => {
-      const date = parseDate(dayExam.day);
-      return isToday(date);
-    });
-  };
+  const firstUpcomingExam =
+    allExamDays.find(
+      (day) => isSameDay(day.date, today) || isAfter(day.date, today),
+    ) ?? allExamDays[0];
+  const firstExamDate = allExamDays[0]?.date;
+  const lastExamDate = allExamDays[allExamDays.length - 1]?.date;
+  const firstExamMonth = firstExamDate ? startOfMonth(firstExamDate) : today;
+  const lastExamMonth = lastExamDate ? startOfMonth(lastExamDate) : today;
+  const [selectedCalendarDate, setSelectedCalendarDate] = useState<
+    Date | undefined
+  >(firstUpcomingExam?.date ?? firstExamDate ?? today);
+  const [calendarMonth, setCalendarMonth] = useState<Date | undefined>(
+    firstUpcomingExam?.date ?? firstExamDate ?? today,
+  );
 
-  const getThisWeekExams = () => {
-    const allExams = organizeExamsByDayAndSubject(
-      timetableData.data,
-      selectedClass,
-    );
-    return allExams.filter((dayExam) => {
-      const date = parseDate(dayExam.day);
-      return isThisWeek(date) && !isToday(date);
-    });
-  };
+  const examDayLookup = useMemo(
+    () =>
+      new Map(allExamDays.map((day) => [getDateKey(day.date), day] as const)),
+    [allExamDays],
+  );
+  const calendarExportEvents = useMemo(
+    () => buildExamCalendarEvents(allExamDays),
+    [allExamDays],
+  );
 
-  const getNextWeekExams = () => {
-    const allExams = organizeExamsByDayAndSubject(
-      timetableData.data,
-      selectedClass,
-    );
-    const nextWeekStart = addWeeks(currentDate, 1);
+  const selectedCalendarDay = selectedCalendarDate
+    ? examDayLookup.get(getDateKey(selectedCalendarDate))
+    : undefined;
 
-    return allExams.filter((dayExam) => {
-      const date = parseDate(dayExam.day);
-      return (
-        isAfter(date, nextWeekStart) &&
-        isBefore(date, addWeeks(nextWeekStart, 1))
-      );
-    });
-  };
-
-  const getLastWeekExams = () => {
-    const allExams = organizeExamsByDayAndSubject(
-      timetableData.data,
-      selectedClass,
-    );
-    const lastWeekStart = subWeeks(currentDate, 1);
-
-    return allExams.filter((dayExam) => {
-      const date = parseDate(dayExam.day);
-      return isAfter(date, lastWeekStart) && isBefore(date, currentDate);
-    });
-  };
-
-  // Render exam cards
-  const renderExamCards = (
-    exams: { day: string; subjects: { name: string; exams: ExamData[] }[] }[],
-  ) => {
-    if (exams.length === 0) {
-      return (
-        <div className="flex flex-col items-center justify-center p-8 text-center">
-          <div className="text-4xl mb-4">📚</div>
-          <h3 className="text-xl font-medium mb-2 dark:text-[#F0F6FC]">
-            No exams scheduled
-          </h3>
-          <p className="text-[#71717A] dark:text-[#D4D4D8]">
-            Enjoy your free time!
-          </p>
-        </div>
-      );
+  useEffect(() => {
+    if (!shouldScrollToDetailsRef.current || !selectedCalendarDay) {
+      return;
     }
 
-    return exams.map((dayExams, dayIndex) => (
-      <div key={dayIndex} className="mb-8">
-        <h3 className="text-lg font-medium mb-4 flex items-center dark:text-[#F0F6FC]">
-          <Calendar className="mr-2 h-5 w-5" />
-          {dayExams.day}
+    shouldScrollToDetailsRef.current = false;
+
+    const timer = window.setTimeout(() => {
+      selectedDayDetailsRef.current?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }, 60);
+
+    return () => window.clearTimeout(timer);
+  }, [selectedCalendarDay]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        downloadDropdownRef.current &&
+        !downloadDropdownRef.current.contains(event.target as Node)
+      ) {
+        setShowDownloadDropdown(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const renderEmptyState = () => {
+    const upcomingLabel = firstUpcomingExam
+      ? `Next scheduled paper is ${firstUpcomingExam.day}.`
+      : "No exam entries are available in the current file.";
+
+    return (
+      <div className="rounded-lg border border-dashed border-[#D4D4D8] bg-[#FAFAFA] px-6 py-12 text-center dark:border-[#303030] dark:bg-[#262626]">
+        <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-[#F4F4F5] text-[#2457A7] dark:bg-[#303030] dark:text-[#4593F8]">
+          <NotebookTabs className="h-5 w-5" />
+        </div>
+        <h3
+          className={clsx(
+            "text-xl font-semibold tracking-tight",
+            primaryTextClasses,
+          )}
+        >
+          No exams scheduled for {formatExamWindowLabel(activeWindow)}
         </h3>
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {dayExams.subjects.map((subject, subjectIndex) => (
-            <div
-              key={subjectIndex}
-              className="text-card-foreground shadow-sm relative overflow-hidden rounded-xl border bg-white dark:bg-[#09090B] dark:border-[#303030]"
+        <p
+          className={clsx(
+            "mx-auto mt-3 max-w-xl text-sm leading-6",
+            mutedTextClasses,
+          )}
+        >
+          {upcomingLabel}
+        </p>
+      </div>
+    );
+  };
+
+  const renderExamCards = (days: DayGroup[]) => {
+    if (days.length === 0) {
+      return renderEmptyState();
+    }
+
+    return days.map((day) => (
+      <section
+        key={day.day}
+        className={clsx("overflow-hidden rounded-lg", panelClasses)}
+      >
+        <div
+          className={clsx(
+            "flex flex-col gap-1 border-b px-4 py-3 sm:flex-row sm:items-end sm:justify-between",
+            subtleSurfaceClasses,
+            "border-[#E4E4E7] dark:border-[#303030]",
+          )}
+        >
+          <h3 className={clsx("text-base font-semibold", primaryTextClasses)}>
+            {day.day}
+          </h3>
+          <p className={clsx("text-sm", mutedTextClasses)}>
+            {day.totalExams} exam {day.totalExams === 1 ? "entry" : "entries"}
+          </p>
+        </div>
+
+        <div className="divide-y divide-[#E4E4E7] dark:divide-[#303030]">
+          {day.subjects.map((subject) => (
+            <article
+              key={`${day.day}-${subject.name}`}
+              className="bg-white dark:bg-[#262626]"
             >
-              <div className="p-4">
-                <div className="mb-3">
-                  <h4 className="text-lg font-medium mb-1 dark:text-[#F0F6FC]">
-                    {subject.name}
-                  </h4>
-                  <div className="flex items-center text-sm text-[#71717A] dark:text-[#D4D4D8]">
-                    <Clock className="mr-1 h-4 w-4" />
-                    {subject.exams[0].start} - {subject.exams[0].end}
+              <div className="space-y-3 px-4 py-4">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h4
+                      className={clsx(
+                        "text-base font-semibold leading-tight",
+                        primaryTextClasses,
+                      )}
+                    >
+                      {subject.name}
+                    </h4>
+                    <div className="mt-2">
+                      <SubjectMeta
+                        classCount={subject.exams.length}
+                        end={subject.end}
+                        start={subject.start}
+                      />
+                    </div>
                   </div>
                 </div>
+
                 <div className="space-y-2">
-                  {subject.exams.map((exam, examIndex) => (
-                    <div
-                      key={examIndex}
-                      className="flex flex-col space-y-1 text-sm"
-                    >
-                      <div className="flex items-center text-[#71717A] dark:text-[#D4D4D8]">
-                        <Users className="mr-2 h-4 w-4" />
-                        <span>{exam.class}</span>
-                      </div>
-                      <div className="flex items-center text-[#71717A] dark:text-[#D4D4D8]">
-                        <MapPin className="mr-2 h-4 w-4" />
-                        <span>{exam.location}</span>
-                      </div>
-                    </div>
+                  {subject.exams.map((exam) => (
+                    <ExamClassRow
+                      key={`${day.day}-${subject.name}-${exam.class}-${exam.location}`}
+                      exam={exam}
+                    />
                   ))}
                 </div>
               </div>
-            </div>
+            </article>
           ))}
         </div>
-      </div>
+      </section>
     ));
   };
 
-  const todayCount = getTodayExams().reduce(
-    (acc, day) =>
-      acc +
-      day.subjects.reduce(
-        (subAcc, subject) => subAcc + subject.exams.length,
-        0,
-      ),
-    0,
+  const renderSubjectClassRows = (subject: SubjectGroup, dayKey: string) => (
+    <div className="mt-3 space-y-2">
+      {subject.exams.map((exam) => (
+        <ExamClassRow
+          key={`${dayKey}-${subject.name}-${exam.class}-${exam.location}`}
+          exam={exam}
+        />
+      ))}
+    </div>
   );
 
-  const thisWeekCount = getThisWeekExams().reduce(
-    (acc, day) =>
-      acc +
-      day.subjects.reduce(
-        (subAcc, subject) => subAcc + subject.exams.length,
-        0,
-      ),
-    0,
+  const renderSelectedDayDetails = () => (
+    <section
+      ref={selectedDayDetailsRef}
+      className={clsx(
+        "overflow-hidden rounded-lg scroll-mt-24 sm:scroll-mt-28",
+        panelClasses,
+      )}
+    >
+      <div className="border-b border-[#E4E4E7] px-3 py-4 dark:border-[#303030] sm:px-4 lg:px-5">
+        <p
+          className={clsx(
+            "text-xs font-semibold uppercase tracking-[0.18em]",
+            mutedTextClasses,
+          )}
+        >
+          Selected Date
+        </p>
+        <h3 className={clsx("mt-2 text-lg font-semibold", primaryTextClasses)}>
+          {selectedCalendarDate
+            ? format(selectedCalendarDate, "EEEE, MMMM d")
+            : "No exam date selected"}
+        </h3>
+        <p className={clsx("mt-2 text-sm", mutedTextClasses)}>
+          {selectedCalendarDay
+            ? `${formatPaperCount(selectedCalendarDay.totalExams)} scheduled`
+            : "Pick a date with papers to see its details."}
+        </p>
+      </div>
+
+      <div className="divide-y divide-[#E4E4E7] dark:divide-[#303030]">
+        {selectedCalendarDay ? (
+          selectedCalendarDay.subjects.map((subject) => (
+            <article
+              key={`${selectedCalendarDay.day}-${subject.name}`}
+              className="px-3 py-4 sm:px-4 lg:px-5"
+            >
+              <div className="flex flex-col justify-between gap-4 md:flex-row">
+                <div className="flex-1">
+                  <h3
+                    className={clsx(
+                      "mb-2 text-2xl font-bold leading-tight",
+                      primaryTextClasses,
+                    )}
+                  >
+                    {subject.name}
+                  </h3>
+
+                  <SubjectMeta
+                    classCount={subject.exams.length}
+                    end={subject.end}
+                    start={subject.start}
+                  />
+                </div>
+              </div>
+
+              {renderSubjectClassRows(subject, selectedCalendarDay.day)}
+            </article>
+          ))
+        ) : (
+          <div
+            className={clsx(
+              "px-3 py-6 text-sm sm:px-4 lg:px-5",
+              mutedTextClasses,
+            )}
+          >
+            No papers are scheduled for the selected date.
+          </div>
+        )}
+      </div>
+    </section>
   );
 
-  const nextWeekCount = getNextWeekExams().reduce(
-    (acc, day) =>
-      acc +
-      day.subjects.reduce(
-        (subAcc, subject) => subAcc + subject.exams.length,
-        0,
-      ),
-    0,
-  );
+  const renderAllExamsWorkspace = () => {
+    if (allExamDays.length === 0) {
+      return renderEmptyState();
+    }
 
-  const lastWeekCount = getLastWeekExams().reduce(
-    (acc, day) =>
-      acc +
-      day.subjects.reduce(
-        (subAcc, subject) => subAcc + subject.exams.length,
-        0,
-      ),
-    0,
-  );
+    let activeMonth = calendarMonth ?? firstExamMonth;
+    const normalizedActiveMonth = startOfMonth(activeMonth);
+
+    if (isBefore(normalizedActiveMonth, firstExamMonth)) {
+      activeMonth = firstExamMonth;
+    } else if (isAfter(normalizedActiveMonth, lastExamMonth)) {
+      activeMonth = lastExamMonth;
+    }
+
+    const monthStart = startOfMonth(activeMonth);
+    const canGoPrevMonth = isAfter(monthStart, firstExamMonth);
+    const canGoNextMonth = isBefore(monthStart, lastExamMonth);
+    const monthDays = buildMonthDays(activeMonth);
+
+    return (
+      <div className="space-y-5">
+        <section
+          className={clsx("min-w-0 overflow-hidden rounded-lg", panelClasses)}
+        >
+          <div className="border-b border-[#E4E4E7] px-3 py-4 dark:border-[#303030] sm:px-4 lg:px-5">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-center gap-2">
+                <h3
+                  className={clsx(
+                    "text-xl font-semibold tracking-tight",
+                    primaryTextClasses,
+                  )}
+                >
+                  {format(activeMonth, "MMM yyyy")}
+                </h3>
+                <button
+                  onClick={() => {
+                    if (canGoPrevMonth) {
+                      setCalendarMonth(subMonths(activeMonth, 1));
+                    }
+                  }}
+                  disabled={!canGoPrevMonth}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-[#E4E4E7] bg-white text-[#4B5563] hover:bg-[#F4F4F5] disabled:cursor-not-allowed disabled:opacity-40 dark:border-[#303030] dark:bg-[#262626] dark:text-[#B2B2B2] dark:hover:bg-[#303030]"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => {
+                    if (canGoNextMonth) {
+                      setCalendarMonth(addMonths(activeMonth, 1));
+                    }
+                  }}
+                  disabled={!canGoNextMonth}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-[#E4E4E7] bg-white text-[#4B5563] hover:bg-[#F4F4F5] disabled:cursor-not-allowed disabled:opacity-40 dark:border-[#303030] dark:bg-[#262626] dark:text-[#B2B2B2] dark:hover:bg-[#303030]"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </button>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+                <button
+                  onClick={() => {
+                    const jumpDate =
+                      firstUpcomingExam?.date ?? firstExamDate ?? today;
+                    setCalendarMonth(jumpDate);
+                    setSelectedCalendarDate(jumpDate);
+                    setAllExamsView("month");
+                  }}
+                  className="rounded-md border border-[#E4E4E7] bg-white px-3 py-2 text-sm font-medium text-[#111827] hover:bg-[#F4F4F5] dark:border-[#303030] dark:bg-[#262626] dark:text-[#F0F6FC] dark:hover:bg-[#303030]"
+                >
+                  {firstUpcomingExam ? "Next Paper" : "First Exam"}
+                </button>
+
+                <div className="inline-flex rounded-md border border-[#E4E4E7] bg-[#FAFAFA] p-1 dark:border-[#303030] dark:bg-[#303030]">
+                  <ViewModeButton
+                    icon={LayoutGrid}
+                    isActive={allExamsView === "month"}
+                    label="Month"
+                    onClick={() => setAllExamsView("month")}
+                  />
+                  <ViewModeButton
+                    icon={Rows3}
+                    isActive={allExamsView === "agenda"}
+                    label="Agenda"
+                    onClick={() => setAllExamsView("agenda")}
+                  />
+                </div>
+
+                {allExamsView === "agenda" ? (
+                  <div ref={downloadDropdownRef} className="relative">
+                    <div
+                      className="flex items-center gap-2"
+                      onClick={() =>
+                        setShowDownloadDropdown((currentState) => !currentState)
+                      }
+                    >
+                      <span
+                        className={clsx(
+                          "text-sm font-medium",
+                          mutedTextClasses,
+                        )}
+                      >
+                        Download
+                      </span>
+                      <button className="flex items-center rounded-full border-2 border-gray-600 p-1 dark:border-[#B2B2B2] dark:text-[#B2B2B2]">
+                        <svg
+                          className="w-2 h-2"
+                          data-slot="icon"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"
+                          ></path>
+                        </svg>
+                      </button>
+                    </div>
+
+                    {showDownloadDropdown ? (
+                      <div className="absolute right-0 top-full z-[9999] mt-2 rounded-lg border border-gray-200 bg-white py-1 shadow-xl dark:border-[#303030] dark:bg-[#262626]">
+                        <button
+                          onClick={() => {
+                            downloadElementAsPDF(
+                              "exam-agenda-export",
+                              "Exam-Agenda.pdf",
+                            );
+                            setShowDownloadDropdown(false);
+                          }}
+                          className="w-full border-b border-gray-200 px-4 py-1 text-left hover:bg-gray-100 dark:border-[#303030] dark:hover:bg-[#3e3e3e]"
+                        >
+                          <span className="text-sm dark:text-[#B2B2B2]">
+                            PDF
+                          </span>
+                        </button>
+                        <button
+                          onClick={() => {
+                            downloadEventsAsICS(
+                              calendarExportEvents,
+                              "Exam-Agenda.ics",
+                              exportLabel,
+                            );
+                            setShowDownloadDropdown(false);
+                          }}
+                          className="w-full border-b border-gray-200 px-4 py-1 text-left hover:bg-gray-100 dark:border-[#303030] dark:hover:bg-[#3e3e3e]"
+                        >
+                          <span className="text-sm dark:text-[#B2B2B2]">
+                            Calendar (.ics)
+                          </span>
+                        </button>
+                        <button
+                          onClick={() => {
+                            downloadElementAsImage(
+                              "exam-agenda-export",
+                              "Exam-Agenda.png",
+                            );
+                            setShowDownloadDropdown(false);
+                          }}
+                          className="w-full px-4 py-1 text-left hover:bg-gray-100 dark:hover:bg-[#3e3e3e]"
+                        >
+                          <span className="text-sm dark:text-[#B2B2B2]">
+                            Image
+                          </span>
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          {allExamsView === "month" ? (
+            <>
+              <div className="grid grid-cols-7 border-b border-[#E4E4E7] bg-[#FAFAFA] dark:border-[#303030] dark:bg-[#303030]">
+                {weekdayLabels.map((day) => (
+                  <div
+                    key={day}
+                    className="px-1 py-2 text-center text-[10px] font-semibold uppercase tracking-[0.12em] text-[#6D7480] dark:text-[#B2B2B2] sm:px-3 sm:py-3 sm:text-[11px] sm:tracking-[0.14em]"
+                  >
+                    <span className="sm:hidden">{day.charAt(0)}</span>
+                    <span className="hidden sm:inline">{day}</span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="grid grid-cols-7">
+                {monthDays.map((date) => {
+                  const dayGroup = examDayLookup.get(getDateKey(date));
+                  const isCurrentMonth = isSameMonth(date, activeMonth);
+                  const isSelected =
+                    !!selectedCalendarDate &&
+                    isSameDay(date, selectedCalendarDate);
+                  const isTodayDate = isToday(date);
+
+                  return (
+                    <button
+                      key={date.toISOString()}
+                      onClick={() => {
+                        setSelectedCalendarDate(date);
+                        if (!isCurrentMonth) {
+                          setCalendarMonth(date);
+                        }
+                        shouldScrollToDetailsRef.current = !!dayGroup;
+                      }}
+                      className={clsx(
+                        "flex min-h-[3.75rem] flex-col border-b border-r border-[#E4E4E7] px-1.5 py-1.5 text-left text-[#111827] transition-colors dark:border-[#303030] dark:text-[#F0F6FC] sm:min-h-[9rem] sm:px-3 sm:py-2",
+                        isSelected
+                          ? "bg-blue-50 dark:bg-[#1E3A5F]"
+                          : "bg-white dark:bg-[#262626]",
+                        dayGroup &&
+                          !isSelected &&
+                          "dark:bg-[#2B313A] dark:hover:bg-[#343B46]",
+                        !isCurrentMonth &&
+                          "bg-[#FAFAFA] text-[#A1A1AA] dark:bg-[#1C1C1C] dark:text-[#6F6F6F]",
+                      )}
+                    >
+                      <div className="mb-1.5 flex items-center justify-between sm:mb-2">
+                        <span
+                          className={clsx(
+                            "inline-flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold sm:h-7 sm:w-7 sm:text-sm",
+                            !isTodayDate &&
+                              !isSelected &&
+                              "text-[#111827] dark:text-[#F0F6FC]",
+                            isTodayDate && !isSelected && accentStrongClasses,
+                            isSelected && accentStrongClasses,
+                          )}
+                        >
+                          {format(date, "d")}
+                        </span>
+                        {dayGroup && dayGroup.subjects.length > 1 ? (
+                          <span
+                            className={clsx(
+                              "inline-flex min-w-5 items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] font-semibold sm:text-[11px]",
+                              accentSoftClasses,
+                            )}
+                          >
+                            {dayGroup.subjects.length}
+                          </span>
+                        ) : null}
+                      </div>
+
+                      {dayGroup ? (
+                        <>
+                          <div className="mt-auto sm:hidden">
+                            <div className="h-1.5 w-full rounded-full bg-[#93C5FD] dark:bg-[#4593F8]" />
+                          </div>
+
+                          <div className="hidden space-y-1.5 mt-2 sm:block">
+                            {dayGroup.subjects.slice(0, 2).map((subject) => (
+                              <div
+                                key={`${dayGroup.day}-${subject.name}`}
+                                className={clsx(
+                                  "rounded-md px-2 py-1 text-left text-[11px] font-medium leading-4",
+                                  accentSoftClasses,
+                                )}
+                              >
+                                <div className="truncate">{subject.name}</div>
+                                <div className="mt-0.5 truncate text-[10px] text-[#5A6B82] dark:text-[#D6E8FF]">
+                                  {subject.start} - {subject.end}
+                                </div>
+                              </div>
+                            ))}
+                            {dayGroup.subjects.length > 2 ? (
+                              <div
+                                className={clsx(
+                                  "text-[11px] font-medium",
+                                  mutedTextClasses,
+                                )}
+                              >
+                                +{dayGroup.subjects.length - 2} more
+                              </div>
+                            ) : null}
+                          </div>
+                        </>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+
+              <div className="p-3 sm:p-4 lg:p-5">
+                {renderSelectedDayDetails()}
+              </div>
+            </>
+          ) : (
+            <div
+              id="exam-agenda-export"
+              className="space-y-6 rounded-lg bg-[#FAFAFA] p-3 dark:bg-[#02040A] sm:p-4 lg:p-5"
+            >
+              {allExamDays.map((day) => (
+                <section
+                  key={day.day}
+                  className="grid gap-4 lg:grid-cols-[9.5rem_minmax(0,1fr)] lg:gap-6"
+                >
+                  <div className="px-1 pt-1">
+                    <h3 className="text-lg font-semibold leading-tight text-[#2457A7] dark:text-[#4593F8]">
+                      {format(day.date, "EEEE, do")}
+                    </h3>
+                    <p
+                      className={clsx(
+                        "mt-1 text-xs font-semibold uppercase tracking-[0.16em]",
+                        mutedTextClasses,
+                      )}
+                    >
+                      {format(day.date, "MMMM yyyy")}
+                    </p>
+                  </div>
+
+                  <div className="space-y-4">
+                    {day.subjects.map((subject) => (
+                      <AgendaPaperCard
+                        key={`${day.day}-${subject.name}`}
+                        subject={subject}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+
+              <div className="flex justify-end pt-4">
+                <div className="inline-flex items-center gap-2 rounded-full border border-[#E4E4E7] bg-white px-3 py-2 text-xs font-medium text-[#52525B] dark:border-[#303030] dark:bg-[#262626] dark:text-[#B2B2B2]">
+                  <img
+                    src={easeChaosLogo}
+                    alt="easeCHAOS"
+                    className="h-4 w-6 object-contain"
+                  />
+                  <span>Exported from easeCHAOS</span>
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    );
+  };
 
   return (
     <div
       className={clsx(
-        "bg-white dark:bg-[#262626] rounded-lg shadow-lg flex flex-col min-h-[80vh]",
+        "min-w-0 overflow-x-hidden space-y-5 sm:space-y-6",
         className,
       )}
     >
-      <div className="p-4 border-b dark:border-[#303030] sticky top-0 bg-white dark:bg-[#262626] rounded-t-md">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div className="flex items-center space-x-2">
-            <div className="flex items-center space-x-2">
-              <ChevronLeft
-                className="h-5 w-5 cursor-pointer hover:text-primary dark:text-[#B2B2B2] dark:hover:text-white"
-                onClick={() =>
-                  setCurrentDate(
-                    (prev) =>
-                      new Date(
-                        prev.getFullYear(),
-                        prev.getMonth(),
-                        prev.getDate() - 7,
-                      ),
-                  )
-                }
+      <div className="flex flex-col gap-3 border-b border-[#E4E4E7] pb-3 dark:border-[#303030] sm:pb-4 lg:flex-row lg:items-center lg:justify-between">
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
+          {examWindows.map((window) => {
+            const isActive = activeWindow === window.id;
+            const count = countGroupedPapers(examGroupsByWindow[window.id]);
+
+            return (
+              <WindowTabButton
+                key={window.id}
+                count={count}
+                isActive={isActive}
+                label={window.shortLabel}
+                onClick={() => setActiveWindow(window.id)}
               />
-              <span className="font-medium dark:text-[#F0F6FC]">
-                {format(currentDate, "MMMM d, yyyy")}
-              </span>
-              <ChevronRight
-                className="h-5 w-5 cursor-pointer hover:text-primary dark:text-[#B2B2B2] dark:hover:text-white"
-                onClick={() =>
-                  setCurrentDate(
-                    (prev) =>
-                      new Date(
-                        prev.getFullYear(),
-                        prev.getMonth(),
-                        prev.getDate() + 7,
-                      ),
-                  )
-                }
-              />
-            </div>
-          </div>
+            );
+          })}
+        </div>
+        <div className="hidden sm:block sm:max-w-[32rem]">
+          <p className={clsx("text-sm", mutedTextClasses)}>
+            {getWindowDescription(activeWindow)}
+          </p>
         </div>
       </div>
 
-      <div className="p-4">
-        <div className="flex space-x-1 bg-[#F4F4F5] dark:bg-[#303030] p-1 rounded-md mb-6">
-          <button
-            onClick={() => setActiveTab("today")}
-            className={clsx(
-              "flex-1 py-2 px-3 rounded-md text-sm font-medium relative",
-              activeTab === "today"
-                ? "bg-white dark:bg-[#262626] shadow-sm text-black dark:text-[#F0F6FC]"
-                : "text-[#71717A] dark:text-[#D4D4D8] hover:bg-gray-200 dark:hover:bg-[#3e3e3e]",
-            )}
-          >
-            Today
-            {todayCount > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-[#52525B] text-white">
-                {todayCount}
-              </span>
-            )}
-          </button>
-          <button
-            onClick={() => setActiveTab("this-week")}
-            className={clsx(
-              "flex-1 py-2 px-3 rounded-md text-sm font-medium relative",
-              activeTab === "this-week"
-                ? "bg-white dark:bg-[#262626] shadow-sm text-black dark:text-[#F0F6FC]"
-                : "text-[#71717A] dark:text-[#D4D4D8] hover:bg-gray-200 dark:hover:bg-[#3e3e3e]",
-            )}
-          >
-            This Week
-            {thisWeekCount > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-[#52525B] text-white">
-                {thisWeekCount}
-              </span>
-            )}
-          </button>
-          <button
-            onClick={() => setActiveTab("next-week")}
-            className={clsx(
-              "flex-1 py-2 px-3 rounded-md text-sm font-medium relative",
-              activeTab === "next-week"
-                ? "bg-white dark:bg-[#262626] shadow-sm text-black dark:text-[#F0F6FC]"
-                : "text-[#71717A] dark:text-[#D4D4D8] hover:bg-gray-200 dark:hover:bg-[#3e3e3e]",
-            )}
-          >
-            Next Week
-            {nextWeekCount > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 text-xs rounded-full bg-[#52525B] text-white">
-                {nextWeekCount}
-              </span>
-            )}
-          </button>
-        </div>
-
-        <div className="mt-6">
-          {activeTab === "today" && renderExamCards(getTodayExams())}
-          {activeTab === "this-week" && renderExamCards(getThisWeekExams())}
-          {activeTab === "next-week" && renderExamCards(getNextWeekExams())}
-          {activeTab === "last-week" && renderExamCards(getLastWeekExams())}
-        </div>
+      <div className="min-w-0 space-y-8">
+        {activeWindow === "all"
+          ? renderAllExamsWorkspace()
+          : renderExamCards(examGroupsByWindow[activeWindow])}
       </div>
     </div>
   );

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -3,7 +3,7 @@ import { useTheme } from "../context/ThemeContext";
 import { useState, useRef, useEffect } from "react";
 import clsx from "clsx";
 
-export default function ThemeToggle({ props }: { props: string }) {
+export default function ThemeToggle({ props = "right-0" }: { props?: string }) {
   const { theme, setTheme } = useTheme();
   const [showDropdown, setShowDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -32,29 +32,32 @@ export default function ThemeToggle({ props }: { props: string }) {
     <div className="relative">
       <button
         onClick={() => setShowDropdown(!showDropdown)}
+        aria-label="Change theme"
         className={clsx(
-          "p-2 rounded-lg",
-          "hover:bg-gray-100 dark:hover:bg-[#303030]",
+          "flex h-10 w-10 items-center justify-center rounded-md border",
+          "border-gray-200 bg-white text-[#3F4652] hover:bg-gray-100",
+          "dark:border-[#2A313C] dark:bg-[#11161D] dark:text-[#C6D0DE] dark:hover:bg-[#182131]",
           "transition-colors",
-          "border border-gray-200 dark:border-[#303030]",
-          "relative flex items-center",
         )}
       >
         {theme === "dark" ? (
-          <Moon className="w-5 h-5 dark:text-[#B2B2B2]" />
+          <Moon className="h-4.5 w-4.5" />
         ) : theme === "light" ? (
-          <Sun className="w-5 h-5" />
+          <Sun className="h-4.5 w-4.5" />
         ) : (
-          <Monitor className="w-5 h-5 dark:text-[#B2B2B2]" />
+          <Monitor className="h-4.5 w-4.5" />
         )}
       </button>
 
       {showDropdown && (
         <div
           ref={dropdownRef}
-          className={`absolute top-full ${props} mt-1 z-[9999]`}
+          className={clsx(
+            "absolute top-full mt-1 z-[9999] origin-top-right",
+            props,
+          )}
         >
-          <div className="w-48 rounded-md shadow-lg bg-white dark:bg-[#262626] ring-1 ring-black ring-opacity-5">
+          <div className="w-44 rounded-md border border-[#E4E4E7] bg-white shadow-lg dark:border-[#2A313C] dark:bg-[#11161D]">
             {themeOptions.map(({ value, icon: Icon, label }) => (
               <button
                 key={value}
@@ -63,13 +66,14 @@ export default function ThemeToggle({ props }: { props: string }) {
                   setShowDropdown(false);
                 }}
                 className={clsx(
-                  "w-full px-4 py-2 text-left flex items-center space-x-2",
-                  "hover:bg-gray-100 dark:hover:bg-[#303030]",
-                  theme === value && "bg-gray-100 dark:bg-[#303030]",
+                  "flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[#3F4652] hover:bg-gray-100",
+                  "dark:text-[#C6D0DE] dark:hover:bg-[#182131]",
+                  theme === value &&
+                    "bg-gray-100 text-[#111827] dark:bg-[#182131] dark:text-[#F0F6FC]",
                 )}
               >
-                <Icon className="w-4 h-4 dark:text-[#B2B2B2]" />
-                <span className="text-sm dark:text-[#B2B2B2]">{label}</span>
+                <Icon className="h-4 w-4" />
+                <span>{label}</span>
               </button>
             ))}
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,67 +1,218 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap");
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
-  html {
-    -webkit-text-size-adjust: 100%;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  }
-  
-  body {
-    @apply bg-[#FAFAFA] dark:bg-[#02040A];
-    min-height: 100vh;
-    /* Extend the background color beyond the viewport */
-    min-height: -webkit-fill-available;
-  }
-  
-  /* Force font weights on iOS */
-  strong, b, h1, h2, h3, h4, h5, h6, 
-  .font-bold, .font-semibold, .font-medium {
-    -webkit-font-smoothing: auto;
-  }
+    html {
+        -webkit-text-size-adjust: 100%;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        font-family:
+            "Inter",
+            -apple-system,
+            BlinkMacSystemFont,
+            system-ui,
+            sans-serif;
+    }
+
+    body {
+        @apply bg-[#FAFAFA] dark:bg-[#02040A];
+        min-height: 100vh;
+        /* Extend the background color beyond the viewport */
+        min-height: -webkit-fill-available;
+    }
+
+    /* Force font weights on iOS */
+    strong,
+    b,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .font-bold,
+    .font-semibold,
+    .font-medium {
+        -webkit-font-smoothing: auto;
+    }
 }
 
 .rdp {
-  --rdp-cell-size: 40px;
-  --rdp-accent-color: #3b82f6;
-  --rdp-background-color: #e5e7eb;
-  margin: 0;
+    --rdp-cell-size: 40px;
+    --rdp-accent-color: #3b82f6;
+    --rdp-background-color: #e5e7eb;
+    margin: 0;
 }
 
 .rdp-button:hover:not([disabled]):not(.rdp-day_selected) {
-  background-color: #f3f4f6;
+    background-color: #f3f4f6;
+}
+
+.exam-calendar {
+    --rdp-cell-size: 39px;
+    --rdp-accent-color: #111827;
+    --rdp-background-color: #f4f4f5;
+    width: 100%;
+}
+
+.dark .exam-calendar {
+    --rdp-accent-color: #f0f6fc;
+    --rdp-background-color: #182131;
+}
+
+.exam-calendar .rdp-months,
+.exam-calendar .rdp-month {
+    width: 100%;
+}
+
+.exam-calendar .rdp-table {
+    width: 100%;
+    max-width: none;
+}
+
+.exam-calendar .rdp-head_cell {
+    color: #6d7480;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.dark .exam-calendar .rdp-head_cell {
+    color: #8f9caf;
+}
+
+.exam-calendar .rdp-button {
+    border-radius: 0.5rem;
+}
+
+.exam-calendar-day {
+    display: flex;
+    min-height: 2.2rem;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: space-between;
+    padding: 0.22rem 0.25rem;
+}
+
+.exam-calendar-day-number {
+    font-size: 0.82rem;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.exam-calendar-day-count {
+    align-self: flex-end;
+    border-radius: 999px;
+    background: #e4e4e7;
+    color: #27272a;
+    font-size: 0.64rem;
+    font-weight: 700;
+    line-height: 1;
+    min-width: 1rem;
+    padding: 0.12rem 0.24rem;
+    text-align: center;
+}
+
+.dark .exam-calendar-day-count {
+    background: #223047;
+    color: #f0f6fc;
+}
+
+.exam-calendar .rdp-day_hasExam:not(.rdp-day_selected) .exam-calendar-day {
+    background: #f4f4f5;
+    color: #111827;
+}
+
+.dark
+    .exam-calendar
+    .rdp-day_hasExam:not(.rdp-day_selected)
+    .exam-calendar-day {
+    background: #182131;
+    color: #f0f6fc;
+}
+
+.exam-calendar .rdp-day_today:not(.rdp-day_selected) .exam-calendar-day {
+    box-shadow: inset 0 0 0 1px #cbd5e1;
+}
+
+.dark .exam-calendar .rdp-day_today:not(.rdp-day_selected) .exam-calendar-day {
+    box-shadow: inset 0 0 0 1px #36507a;
+}
+
+.exam-calendar .rdp-day_selected .exam-calendar-day {
+    background: #111827;
+    color: #fafafa;
+}
+
+.dark .exam-calendar .rdp-day_selected .exam-calendar-day {
+    background: #223047;
+    color: #f0f6fc;
+}
+
+.exam-calendar .rdp-day_selected .exam-calendar-day-count {
+    background: rgba(255, 255, 255, 0.18);
+    color: inherit;
+}
+
+.dark .exam-calendar .rdp-day_selected .exam-calendar-day-count {
+    background: rgba(255, 255, 255, 0.16);
+}
+
+@media (min-width: 640px) {
+    .exam-calendar {
+        --rdp-cell-size: 48px;
+    }
+
+    .exam-calendar .rdp-head_cell {
+        font-size: 0.72rem;
+        letter-spacing: 0.12em;
+    }
+
+    .exam-calendar-day {
+        min-height: 2.5rem;
+        padding: 0.35rem 0.4rem;
+    }
+
+    .exam-calendar-day-number {
+        font-size: 0.92rem;
+    }
+
+    .exam-calendar-day-count {
+        font-size: 0.7rem;
+        min-width: 1.2rem;
+        padding: 0.18rem 0.34rem;
+    }
 }
 
 .animate-slide-in {
-  animation: slideIn 0.5s forwards;
+    animation: slideIn 0.5s forwards;
 }
 
 @keyframes slideIn {
-  from {
-      transform: translateY(-20px);
-      opacity: 0;
-  }
-  to {
-      transform: translateY(0);
-      opacity: 1;
-  }
+    from {
+        transform: translateY(-20px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
 }
 
-
 .animate-fade-out {
-  animation: fadeOut 0.5s forwards;
+    animation: fadeOut 0.5s forwards;
 }
 
 @keyframes fadeOut {
-  from {
-      opacity: 1;
-  }
-  to {
-      opacity: 0;
-  }
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
 }

--- a/frontend/src/pages/ExamPage.tsx
+++ b/frontend/src/pages/ExamPage.tsx
@@ -1,9 +1,50 @@
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, CalendarDays, Layers3 } from "lucide-react";
 import ExamView from "../components/ExamView";
 import ThemeToggle from "../components/ThemeToggle";
 import { TimetableData } from "../types";
+import { departments, years } from "../constants/departments";
+
+const parseExamDate = (dateLabel: string) =>
+  new Date(dateLabel.replace(/(\d+)(st|nd|rd|th)/g, "$1"));
+
+const getGroupedPaperCount = (examData: TimetableData | null) => {
+  if (!examData) return 0;
+
+  const paperKeys = new Set(
+    examData.data.flatMap((day) =>
+      day.data.map((exam) => `${day.day}::${exam.value}`),
+    ),
+  );
+
+  return paperKeys.size;
+};
+
+const fetchExamTimetable = async (dept: string, year: string) => {
+  const timestamp = new Date().getTime();
+  const response = await fetch(
+    `${import.meta.env.VITE_API_URL}/get_time_table?t=${timestamp}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+      },
+      body: JSON.stringify({
+        filename: "Draft_1_ex",
+        class_pattern: `${dept} ${year}`,
+        is_exam: true,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch exam data");
+  }
+
+  return response.json() as Promise<TimetableData>;
+};
 
 export default function ExamPage() {
   const { dept, year } = useParams();
@@ -11,7 +52,6 @@ export default function ExamPage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [examData, setExamData] = useState<TimetableData | null>(null);
-  const [selectedClass, setSelectedClass] = useState<string>("all");
 
   useEffect(() => {
     if (!dept || !year) {
@@ -24,28 +64,7 @@ export default function ExamPage() {
       setError(null);
 
       try {
-        const timestamp = new Date().getTime();
-        const response = await fetch(
-          `${import.meta.env.VITE_API_URL}/get_time_table?t=${timestamp}`,
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "Cache-Control": "no-cache, no-store, must-revalidate",
-            },
-            body: JSON.stringify({
-              filename: "Draft_1_ex",
-              class_pattern: `${dept} ${year}`,
-              is_exam: true,
-            }),
-          },
-        );
-
-        if (!response.ok) {
-          throw new Error("Failed to fetch exam data");
-        }
-
-        const data = await response.json();
+        const data = await fetchExamTimetable(dept, year);
         setExamData(data);
       } catch (err) {
         setError((err as Error).message || "Failed to load exam timetable");
@@ -69,12 +88,28 @@ export default function ExamPage() {
   };
 
   const classes = getUniqueClasses();
+  const selectedDepartment = departments.find((entry) => entry.id === dept);
+  const selectedYear = years.find((entry) => String(entry.id) === year);
+  const totalDisplayedPapers = getGroupedPaperCount(examData);
+  const uniqueExamDays = examData
+    ? Array.from(new Set(examData.data.map((day) => day.day))).sort(
+        (left, right) =>
+          parseExamDate(left).getTime() - parseExamDate(right).getTime(),
+      )
+    : [];
+  const firstExamDay = uniqueExamDays[0];
+  const lastExamDay = uniqueExamDays[uniqueExamDays.length - 1];
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-[#FAFAFA] dark:bg-[#02040A] flex items-center justify-center">
-        <div className="text-[#71717A] dark:text-[#D4D4D8]">
-          Loading exam timetable...
+      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFA] dark:bg-[#02040A]">
+        <div className="rounded-lg border border-[#E4E4E7] bg-white px-8 py-10 text-center shadow-sm dark:border-[#303030] dark:bg-[#262626]">
+          <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-md bg-[#F4F4F5] text-[#2457A7] dark:bg-[#303030] dark:text-[#4593F8]">
+            <CalendarDays className="h-5 w-5" />
+          </div>
+          <div className="text-[#71717A] dark:text-[#B2B2B2]">
+            Loading exam timetable...
+          </div>
         </div>
       </div>
     );
@@ -82,16 +117,18 @@ export default function ExamPage() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-[#FAFAFA] dark:bg-[#02040A] flex items-center justify-center">
-        <div className="text-red-500">{error}</div>
+      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFA] dark:bg-[#02040A]">
+        <div className="rounded-lg border border-red-200 bg-white px-8 py-10 text-center shadow-sm dark:border-red-900/50 dark:bg-[#262626]">
+          <div className="text-red-500">{error}</div>
+        </div>
       </div>
     );
   }
 
   if (!examData) {
     return (
-      <div className="min-h-screen bg-[#FAFAFA] dark:bg-[#02040A] flex items-center justify-center">
-        <div className="text-[#71717A] dark:text-[#D4D4D8]">
+      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFA] dark:bg-[#02040A]">
+        <div className="text-[#71717A] dark:text-[#B2B2B2]">
           No exam timetable found.
         </div>
       </div>
@@ -99,44 +136,71 @@ export default function ExamPage() {
   }
 
   return (
-    <div className="bg-[#FAFAFA] dark:bg-[#02040A] min-h-screen">
-      <div className="h-full w-full relative max-w-6xl mx-auto p-4">
-        <div className="bg-white dark:bg-[#262626] rounded-lg shadow-lg flex flex-col h-full">
-          <div className="p-4 border-b dark:border-[#303030] sticky top-0 bg-white dark:bg-[#262626] z-50 rounded-t-md">
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-              <div className="flex items-center gap-4">
+    <div className="min-h-screen overflow-x-hidden bg-[#FAFAFA] dark:bg-[#02040A]">
+      <div className="relative h-full w-full overflow-x-hidden px-3 py-3 sm:px-4 lg:px-6 xl:px-8">
+        <div className="z-20 border-b bg-[#FAFAFA] px-2 py-4 dark:border-[#303030] dark:bg-[#02040A] sm:sticky sm:top-0 lg:px-0">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-start gap-3 sm:gap-4">
                 <button
                   onClick={() => navigate("/")}
-                  className="border border-[#1B1B1B] dark:border-[#303030] p-1.5 rounded-md hover:bg-gray-100 dark:hover:bg-[#303030]"
+                  className="rounded-md border border-[#1B1B1B] p-1.5 hover:bg-gray-100 dark:border-[#303030] dark:bg-[#262626] dark:hover:bg-[#303030]"
                 >
-                  <ArrowLeft className="w-4 h-4 dark:text-[#B2B2B2]" />
+                  <ArrowLeft className="h-4 w-4 dark:text-[#B2B2B2]" />
                 </button>
-                <h1 className="text-2xl font-bold dark:text-[#F0F6FC]">
-                  Exam Schedule
-                </h1>
+
+                <div className="min-w-0">
+                  <h1 className="text-xl font-bold tracking-tight text-[#111827] dark:text-[#F0F6FC] sm:text-2xl">
+                    {dept} {selectedYear?.name ?? year} Exam Schedule
+                  </h1>
+                  <p className="mt-1 text-[0.75rem] text-[#71717A] dark:text-[#B2B2B2]">
+                    {selectedDepartment?.name ?? "Selected department"}, level{" "}
+                    {selectedYear?.name ?? year}
+                  </p>
+                </div>
               </div>
 
-              <div className="flex items-center gap-4 z-10">
-                <select
-                  value={selectedClass}
-                  onChange={(e) => setSelectedClass(e.target.value)}
-                  className="w-full bg-[#F4F4F5] dark:bg-[#262626] p-2 border border-gray-300 dark:border-[#303030] rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:text-[#D4D4D8]"
-                >
-                  <option value="all">All Classes</option>
-                  {classes.map((cls) => (
-                    <option key={cls} value={cls}>
-                      {cls}
-                    </option>
-                  ))}
-                </select>
-                <ThemeToggle props="-right-5" />
+              <ThemeToggle />
+            </div>
+
+            <div className="flex flex-wrap justify-center items-center gap-x-4 gap-y-2 text-sm text-[#5B6270] dark:text-[#B2B2B2]">
+              <div className="inline-flex items-center gap-2">
+                <Layers3 className="h-4 w-4 text-[#6D7480] dark:text-[#B2B2B2]" />
+                <span className="font-medium text-[#111827] dark:text-[#F0F6FC]">
+                  {classes.length}
+                </span>
+                <span>classes</span>
+              </div>
+
+              <div className="hidden h-4 w-px bg-[#E4E4E7] dark:bg-[#303030] sm:block" />
+
+              <div className="inline-flex items-center gap-2">
+                <CalendarDays className="h-4 w-4 text-[#6D7480] dark:text-[#B2B2B2]" />
+                <span className="font-medium text-[#111827] dark:text-[#F0F6FC]">
+                  {totalDisplayedPapers}
+                </span>
+                <span>papers</span>
+              </div>
+
+              <div className="hidden h-4 w-px bg-[#E4E4E7] dark:bg-[#303030] sm:block" />
+
+              <div className="inline-flex min-w-0 items-center gap-2">
+                <CalendarDays className="h-4 w-4 flex-none text-[#6D7480] dark:text-[#B2B2B2]" />
+                <span className="truncate font-medium text-[#111827] dark:text-[#F0F6FC]">
+                  {firstExamDay && lastExamDay
+                    ? `${firstExamDay} to ${lastExamDay}`
+                    : "No exam dates loaded"}
+                </span>
               </div>
             </div>
           </div>
+        </div>
 
-          <div className="flex-1 overflow-auto p-4">
-            <ExamView timetableData={examData} selectedClass={selectedClass} />
-          </div>
+        <div className="px-1 py-5 sm:px-2 lg:px-0">
+          <ExamView
+            timetableData={examData}
+            exportLabel={`${dept} ${selectedYear?.name ?? year} Exam Schedule`}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/utils/downloadUtils.ts
+++ b/frontend/src/utils/downloadUtils.ts
@@ -1,6 +1,14 @@
 import { toPng } from "html-to-image";
 import html2pdf from "html2pdf.js";
 
+interface CalendarExportEvent {
+  start: Date;
+  end: Date;
+  summary: string;
+  description?: string;
+  location?: string;
+}
+
 const QUALITY = {
   mobile: {
     pixelRatio: 1.5,
@@ -22,9 +30,8 @@ async function prepareElement(elementId: string) {
   const node = document.getElementById(elementId);
   if (!node) throw new Error("Element not found");
 
-  // Detect theme by checking if body has dark-theme class
-  const isDarkTheme = document.body.classList.contains("dark-theme");
-  const backgroundColor = isDarkTheme ? "#121212" : "white"; // Using a dark gray for dark mode
+  const isDarkTheme = document.documentElement.classList.contains("dark");
+  const backgroundColor = isDarkTheme ? "#02040A" : "#FAFAFA";
 
   // Hide time indicator if exists
   const timeIndicator = node.querySelector(".time-indicator") as HTMLElement;
@@ -48,6 +55,47 @@ async function prepareElement(elementId: string) {
   return { dataUrl, backgroundColor }; // Return both for PDF generation
 }
 
+function downloadBlob(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.download = fileName;
+  link.href = url;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function escapeIcsText(value: string) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;");
+}
+
+function formatIcsDateTime(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+
+  return `${year}${month}${day}T${hours}${minutes}${seconds}`;
+}
+
+function formatUtcIcsTimestamp(date: Date) {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const hours = String(date.getUTCHours()).padStart(2, "0");
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+  const seconds = String(date.getUTCSeconds()).padStart(2, "0");
+
+  return `${year}${month}${day}T${hours}${minutes}${seconds}Z`;
+}
+
 export async function downloadElementAsImage(
   elementId: string,
   fileName: string
@@ -64,6 +112,57 @@ export async function downloadElementAsImage(
   } catch (error) {
     console.error("Failed to download image:", error);
     alert("Failed to download image. Please try again.");
+  }
+}
+
+export function downloadEventsAsICS(
+  events: CalendarExportEvent[],
+  fileName: string,
+  calendarName = "EaseCHAOS Exam Schedule"
+) {
+  try {
+    const dtStamp = formatUtcIcsTimestamp(new Date());
+    const lines = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//EaseCHAOS//Exam Schedule//EN",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      `X-WR-CALNAME:${escapeIcsText(calendarName)}`,
+    ];
+
+    events.forEach((event, index) => {
+      lines.push(
+        "BEGIN:VEVENT",
+        `UID:${formatIcsDateTime(event.start)}-${index}@easechaos.app`,
+        `DTSTAMP:${dtStamp}`,
+        `DTSTART:${formatIcsDateTime(event.start)}`,
+        `DTEND:${formatIcsDateTime(event.end)}`,
+        `SUMMARY:${escapeIcsText(event.summary)}`,
+      );
+
+      if (event.location) {
+        lines.push(`LOCATION:${escapeIcsText(event.location)}`);
+      }
+
+      if (event.description) {
+        lines.push(`DESCRIPTION:${escapeIcsText(event.description)}`);
+      }
+
+      lines.push("END:VEVENT");
+    });
+
+    lines.push("END:VCALENDAR");
+
+    downloadBlob(
+      new Blob([lines.join("\r\n")], {
+        type: "text/calendar;charset=utf-8",
+      }),
+      fileName
+    );
+  } catch (error) {
+    console.error("Failed to download ICS:", error);
+    alert("Failed to download calendar file. Please try again.");
   }
 }
 


### PR DESCRIPTION
## Summary
Adds the redesigned exam schedule experience, export support, and updated exam workbook parsing.

## Testing
Built the frontend in Docker, validated the exam API against the updated workbook, and exercised the PNG/PDF/ICS agenda exports in the running app.

## Notes
The exam UI groups repeated class rows for the same paper into a single visible paper entry, so counts now align with month and agenda views.
